### PR TITLE
changed link in examples.md

### DIFF
--- a/Input/getting-started/examples.md
+++ b/Input/getting-started/examples.md
@@ -2,6 +2,6 @@ Title: Examples
 Description: Where to find usage examples.
 Order: 6
 ---
-There are a number of [examples of Wyam sites in the GitHub repository](https://github.com/Wyamio/Wyam/tree/master/Examples). They are designed to showcase different modules and techniques.
+There are a number of [examples of Wyam sites in the GitHub repository](https://github.com/Wyamio/Wyam/tree/master/examples). They are designed to showcase different modules and techniques.
 
 There are also a number of sites that use Wyam and have source code available. Check out the [Community](/community) page for more details.


### PR DESCRIPTION
I get a 404 using the example link. the new link should work.
