### PR TITLE
Added missing space in API docs page title

### DIFF
--- a/Input/api/_ApiLayout.cshtml
+++ b/Input/api/_ApiLayout.cshtml
@@ -8,7 +8,7 @@
 		containingTypeString = containingTypeString + containingType.String("DisplayName") + ".";
 		containingType = containingType.Get<IDocument>("ContainingType");
 	}
-	ViewData["Title"] = "API - " + containingTypeString + Model["DisplayName"] + Model["SpecificKind"];
+	ViewData["Title"] = "API - " + containingTypeString + Model["DisplayName"] + " " + Model["SpecificKind"];
 }
 
 @section Search {	


### PR DESCRIPTION
Right now it looks weird: `Wyam - API - WyamNamespace`, fixes it to make it appear like `Wyam - API - Wyam Namespace`.
