### PR TITLE
Explicitly show fluent method in Default doc

### DIFF
--- a/Input/getting-started/defaults.md
+++ b/Input/getting-started/defaults.md
@@ -19,7 +19,7 @@ For reference, the full default configuration script is:
 Pipelines.Add("Content",
     ReadFiles("*.md"),
     FrontMatter(Yaml()),
-    Markdown(),
+    Markdown().EscapeAt(true),
     Concat(
         ReadFiles("*.cshtml").Where(x => Path.GetFileName(x)[0] != '_'),
         FrontMatter(Yaml())


### PR DESCRIPTION
New users may not be aware of the `Markdown` module's fluent method `EscapeAt()`.
Explicitly adding it to the Defaults documentation exposes this option for discovery.
