### PR TITLE
Added missing static declaration

### DIFF
--- a/Input/getting-started/configuration.md
+++ b/Input/getting-started/configuration.md
@@ -88,7 +88,7 @@ using System.IO;
 
 public static class Helpers
 {
-    public string GetWriteExtension()
+    public static string GetWriteExtension()
     {
         return ".html";
     }


### PR DESCRIPTION
I've seen that the `static` was missing for the example to build successfully. Fixed it!
