### PR TITLE
Fixed a typo in deployment.md

### DIFF
--- a/Input/getting-started/deployment.md
+++ b/Input/getting-started/deployment.md
@@ -6,7 +6,7 @@ One of the many benefits of static generation is that the end result is a collec
 
 # Using Cake
 ---
-For more advanced deployment scenarios Wyam includes an official [Cake Build](http://cakebuild.net/) addin called [Cake.Wyam](https://www.nuget.org/packages/Cake.Wyam). This allows you to integrate Wyam into a more general Cake-based build and deployment process. To use it, yuo must include the appropriate `#tool` and `#addin` directive at the top of your Cake script (to load the Wyam engine and the Cake addin respectively). Note that you'll need to use the special URI syntax below since Wyam packages are still prerelease (due to having dependencies on other prerelease packages).
+For more advanced deployment scenarios Wyam includes an official [Cake Build](http://cakebuild.net/) addin called [Cake.Wyam](https://www.nuget.org/packages/Cake.Wyam). This allows you to integrate Wyam into a more general Cake-based build and deployment process. To use it, you must include the appropriate `#tool` and `#addin` directive at the top of your Cake script (to load the Wyam engine and the Cake addin respectively). Note that you'll need to use the special URI syntax below since Wyam packages are still prerelease (due to having dependencies on other prerelease packages).
 
 ```
 #tool nuget:?package=Wyam&prerelease


### PR DESCRIPTION
Found an errant 'yuo' in the 'Using Cake' paragraph

I don't know why it lit up with so much on the merge comparison.
